### PR TITLE
Update abstractrequest.zep

### DIFF
--- a/phalcon/http/message/abstractrequest.zep
+++ b/phalcon/http/message/abstractrequest.zep
@@ -17,6 +17,7 @@ namespace Phalcon\Http\Message;
 use Phalcon\Http\Message\AbstractMessage;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\StreamInterface;
+use Psr\Http\Message\UriInterface;
 
 /**
  * Abstract class to offer common message methods for PSR-7


### PR DESCRIPTION
Used correct UriInterface to prevent:

Declaration of Phalcon\Http\Message\AbstractRequest::withUri(Phalcon\Http\Message\UriInterface $uri, $preserveHost = NULL): Psr\Http\Message\RequestInterface must be compatible with Psr\Http\Message\RequestInterface::withUri(Psr\Http\Message\UriInterface $logger, $preserveHost = NULL)

Hello!

* Type: bug fix | new feature | code quality | documentation
* Link to issue:

**In raising this pull request, I confirm the following (please check boxes):**

- [ ] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [ ] I have checked that another pull request for this purpose does not exist.
- [ ] I wrote some tests for this PR.

Small description of change:

Thanks

